### PR TITLE
Update sputility.js \\ SPUserFIeld as hyperlinks, localization of SPBooleanField

### DIFF
--- a/dist/sputility.js
+++ b/dist/sputility.js
@@ -1176,7 +1176,7 @@ var SPUtility = (function ($) {
    // overriding the default MakeReadOnly function
    // translate true/false to Yes/No
    SPBooleanField.prototype.MakeReadOnly = function () {
-      return this._makeReadOnly(this.GetValueString());
+      return this._makeReadOnly(this.GetValueString(stringYES, stringNO));
    };
 
    /*


### PR DESCRIPTION
Two changes made.
1. show SPUserFIeld when use method GetValueString as hyperlinks but not in a plain text. SP normally shows this type of field as hyperlinks on display form.
2. added localization functionality to SPBooleanField. now you can specify how 'Yes' and 'No' in your native language should look like.