### PR TITLE
function SPUserField2013(fieldParams) \\ peoplepicker div

### DIFF
--- a/dist/sputility.js
+++ b/dist/sputility.js
@@ -1596,7 +1596,7 @@ var SPUtility = (function ($) {
 
       // sharepoint 2013 uses a special autofill named SPClientPeoplePicker
       // _layouts/15/clientpeoplepicker.debug.js
-      var pickerDiv = $(this.Controls).children()[0];
+      var pickerDiv = $(this.Controls).find('.sp-peoplepicker-topLevel')[0];
       this.ClientPeoplePicker = window.SPClientPeoplePicker.SPClientPeoplePickerDict[$(pickerDiv).attr('id')];
       this.EditorInput = $(this.Controls).find("[id$='_EditorInput']")[0];
 


### PR DESCRIPTION
Hi, when you use standard (not modified by JSlink\CSR) field **SPUserField2013**, this part of code works just fine:

`var pickerDiv = $(this.Controls).children()[0];`

But if you have .sp-peoplepicker-topLevel div not in the root then you might face issues.

I suggest  to change to something like that:

`var pickerDiv = $(this.Controls).find('.sp-peoplepicker-topLevel')[0];`

By that code you make sure that you get a right div no matter what.

What pluses and minuses i see.
- it impacts performance. jquery children works faster than find.
- you add support for modified **SPUserField2013**
- avoid possible issues in the future.

I'm not sure that it need to be 'fixed' but i will give you an idea. The decision is yours...
