### PR TITLE
SPNumberField.prototype.SetValue // thousand separator

### DIFF
--- a/dist/sputility.js
+++ b/dist/sputility.js
@@ -477,7 +477,7 @@ var SPUtility = (function ($) {
    // override SetValue function to prevent NaN
    SPNumberField.prototype.SetValue = function (value) {
       $(this.Textbox).val(value);
-      this._updateReadOnlyLabel(this.GetValueString());
+      this._updateReadOnlyLabel(this.GetValueString().replace(/\B(?=(\d{3})+(?!\d))/g, Z.thousandsSeparator));
       return this;
    };
 


### PR DESCRIPTION
Hi, now if you set value in SPNumberField you get something like this "123456.11".

SharePoint works fine with format something like this "123 456.11" or "123,456.11" and by the way it's more user friendly.

I propose to change prototype for SPNumberField.
